### PR TITLE
Migrate plugin-shared code from AWX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,6 +185,7 @@ repos:
     alias: mypy-py313
     name: MyPy, for Python 3.13
     additional_dependencies:
+    - django-types  # FIXME: delete this line once Django is no longer imported
     - hypothesis
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
@@ -198,6 +199,7 @@ repos:
     alias: mypy-py312
     name: MyPy, for Python 3.12
     additional_dependencies:
+    - django-types  # FIXME: delete this line once Django is no longer imported
     - hypothesis
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
@@ -211,6 +213,7 @@ repos:
     alias: mypy-py311
     name: MyPy, for Python 3.11
     additional_dependencies:
+    - django-types  # FIXME: delete this line once Django is no longer imported
     - hypothesis
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest

--- a/_type_stubs/awx/main/models/credential.pyi
+++ b/_type_stubs/awx/main/models/credential.pyi
@@ -1,0 +1,10 @@
+class ManagedCredentialType:
+    def __init__(
+        self,
+        namespace: str,
+        name: str,
+        kind: str,
+        inputs: dict[str, list[dict[str, bool | str] | str]],
+        injectors: dict[str, dict[str, str]] | None = None,
+        managed: bool = False,
+    ): ...

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,12 @@ myst_substitutions = {
 }
 myst_heading_anchors = 3
 
+# -- Options for sphinx.ext.autodoc extension --------------------------------
+
+autodoc_default_options = {
+    'ignore-module-all': True,
+}
+
 # -- Options for sphinxcontrib.apidoc extension ------------------------------
 
 apidoc_excluded_paths = []

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -5,3 +5,4 @@ namespace
 Pre
 Submodules
 Subpackages
+VMware

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 Ansible
+filesystem
 hasn
 namespace
 Pre

--- a/src/awx_plugins/interfaces/_temporary_private_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_api.py
@@ -1,0 +1,39 @@
+# pylint: disable=fixme
+"""Shared stubs from ``awx`` managed credential type.
+
+The hope is that it will be refactored into something more standardized.
+"""
+
+
+try:
+    # pylint: disable-next=unused-import
+    from awx.main.models.credential import (  # noqa: WPS433
+        ManagedCredentialType,
+    )
+except ImportError:  # FIXME: eventually, this should not exist
+    from dataclasses import dataclass  # noqa: WPS433
+
+    @dataclass(frozen=True)
+    class ManagedCredentialType:  # type: ignore[no-redef]  # noqa: WPS440
+        """Managed credential type stub."""
+
+        namespace: str
+        """Plugin namespace."""
+
+        name: str
+        """Plugin name within the namespace."""
+
+        kind: str
+        """Plugin category."""
+
+        inputs: dict[str, list[dict[str, bool | str] | str]]
+        """UI input fields schema."""
+
+        injectors: dict[str, dict[str, str]] | None = None
+        """Injector hook parameters."""
+
+        managed: bool = False
+        """Flag for whether this plugin instance is managed."""
+
+
+__all__ = ()  # noqa: WPS410

--- a/src/awx_plugins/interfaces/_temporary_private_container_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_container_api.py
@@ -1,0 +1,59 @@
+"""Shared container path mapping from ``awx``.
+
+The hope is that it will find a better home one day.
+"""
+
+import os
+import pathlib
+
+
+__all__ = ()  # noqa: WPS410
+
+
+CONTAINER_ROOT = '/runner'
+"""The root of the private data directory as seen from inside of the container
+running a job."""
+
+
+def get_incontainer_path(
+        path: os.PathLike[str] | str,
+        private_data_dir: os.PathLike[str] | str,
+) -> str:
+    """Produce an in-container path string.
+
+    Given a path inside of the host machine filesystem, this returns the
+    expected path which would be observed by the job running inside of the EE
+    container.
+    This only handles the volume mount from ``private_data_dir``
+    to ``/runner``.
+
+    :param path: Host-side path view.
+    :type path: os.PathLike[str] | str
+
+    :param private_data_dir: Host-side directory mounted to ``/runner``
+                             in container.
+    :type private_data_dir: os.PathLike[str] | str
+
+    :raises RuntimeError: If the private data directory is not absolute or does
+                          not contain the path.
+
+    :returns: In-container path.
+    :rtype: str
+    """
+    if not os.path.isabs(private_data_dir):
+        raise RuntimeError('The private_data_dir path must be absolute')
+
+    container_root = pathlib.Path(CONTAINER_ROOT)
+
+    # NOTE: Due to how `tempfile.mkstemp()` works, we are probably passed
+    # NOTE: a resolved `path`, but unresolved `private_data_dir``.
+    resolved_path = pathlib.Path(path).resolve()
+    resolved_pdd = pathlib.Path(private_data_dir).resolve()
+
+    try:
+        return str(container_root / resolved_path.relative_to(resolved_pdd))
+    except ValueError as val_err:
+        raise RuntimeError(
+            f'Cannot convert path {resolved_path !s} '
+            f'unless it is a subdir of {resolved_pdd !s}',
+        ) from val_err

--- a/src/awx_plugins/interfaces/_temporary_private_django_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_django_api.py
@@ -1,0 +1,62 @@
+# pylint: disable=fixme
+"""Shared Django-coupled helpers from ``awx``.
+
+The hope is that it will find a better home one day.
+"""
+
+try:  # noqa: WPS503
+    # FIXME: delete Django imports from this project
+    from django.conf import settings  # noqa: WPS433
+except ImportError:
+    def get_vmware_certificate_validation_setting() -> bool:
+        """Retrieve VMware certificate validation platform toggle.
+
+        This is a stub for when there is no Django in the environment.
+
+        :returns: Whether the certificates should be validated.
+        :rtype: bool
+        """
+        return True
+else:  # FIXME: eventually, this should not exist  # pragma: no cover
+    def get_vmware_certificate_validation_setting() -> bool:  # noqa: WPS440
+        """Retrieve VMware certificate validation platform toggle.
+
+        :returns: Whether the certificates should be validated.
+        :rtype: bool
+        """
+        return settings.VMWARE_VALIDATE_CERTS
+
+
+try:
+    # FIXME: delete Django imports from this project
+    # pylint: disable-next=unused-import
+    from django.utils.translation import gettext_lazy  # noqa: WPS433
+except ImportError:  # FIXME: eventually, this should not exist
+    def gettext_lazy(message: str) -> str:  # noqa: WPS440
+        """Emulate a Django-imported lazy translator.
+
+        :param message: Translatable string.
+        :type message: str
+        :returns: Whatever's been passed in.
+        :rtype: str
+        """
+        return message
+
+
+try:
+    # FIXME: delete Django imports from this project
+    # pylint: disable-next=unused-import
+    from django.utils.translation import gettext_noop  # noqa: WPS433
+except ImportError:  # FIXME: eventually, this should not exist
+    def gettext_noop(message: str) -> str:  # noqa: WPS440
+        """Emulate a Django-imported no-op.
+
+        :param message: Translatable string.
+        :type message: str
+        :returns: Whatever's been passed in.
+        :rtype: str
+        """
+        return message
+
+
+__all__ = ()  # noqa: WPS410

--- a/src/awx_plugins/interfaces/_temporary_private_licensing_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_licensing_api.py
@@ -1,0 +1,26 @@
+"""Shared runtime detection from ``awx``.
+
+The hope is that it will find a better home one day.
+"""
+
+import functools
+import pathlib
+
+
+__all__ = ()  # noqa: WPS410
+
+
+@functools.cache
+def detect_server_product_name() -> str:
+    """Compute the official runtime name.
+
+    :returns: Runtime name.
+    :rtype: str
+    """
+    custom_version_file_present = pathlib.Path(
+        '/var/lib/awx/.tower_version',
+    ).exists()
+    return (
+        'Red Hat Ansible Automation Platform' if custom_version_file_present
+        else 'AWX'
+    )

--- a/src/awx_plugins/interfaces/py.typed
+++ b/src/awx_plugins/interfaces/py.typed
@@ -1,0 +1,5 @@
+`awx_plugins.interfaces` is a project declaring standard plugin interfaces for
+AWX. It's sole purpose is exposing a public API.
+This PEP 561 marker file exists to let the type checkers know that this project
+has type annotations declared. Additionally, this is useful
+for type-checking our own tests since they make corresponding imports.

--- a/tests/_temporary_private_api_test.py
+++ b/tests/_temporary_private_api_test.py
@@ -1,0 +1,8 @@
+"""Tests for the temporarily hosted private helpers."""
+
+from awx_plugins.interfaces._temporary_private_api import ManagedCredentialType
+
+
+def test_managed_credential_type_instantiation() -> None:
+    """Check that managed credential type can be instantiated."""
+    assert ManagedCredentialType('', '', '', {})

--- a/tests/_temporary_private_container_api_test.py
+++ b/tests/_temporary_private_container_api_test.py
@@ -1,0 +1,89 @@
+"""Tests for the temporarily hosted private helpers."""
+
+import os
+import pathlib
+from collections.abc import Callable
+
+import pytest
+
+from awx_plugins.interfaces._temporary_private_container_api import (
+    CONTAINER_ROOT,
+    get_incontainer_path,
+)
+
+
+PathOrStringType = os.PathLike[str] | str
+PathToTypeCallableType = Callable[[PathOrStringType], PathOrStringType]
+
+
+@pytest.mark.parametrize(
+    ('host_path', 'host_runner_path', 'expected_incontainer_path'),
+    (
+        ('/root', '/', f'{CONTAINER_ROOT}/root'),
+        ('/tmp/private/subdir', '/tmp/private', f'{CONTAINER_ROOT}/subdir'),
+    ),
+)
+@pytest.mark.parametrize('convert_path_to_type', (pathlib.Path, str))
+@pytest.mark.parametrize('convert_runner_path_to_type', (pathlib.Path, str))
+def test_host_to_incontainer_path_conversion(
+        host_path: os.PathLike[str] | str,
+        host_runner_path: os.PathLike[str] | str,
+        expected_incontainer_path: str,
+        convert_path_to_type: PathToTypeCallableType,
+        convert_runner_path_to_type: PathToTypeCallableType,
+) -> None:
+    """Ensure the positive case path conversion works."""
+    typed_host_path = convert_path_to_type(host_path)
+    typed_host_runner_path = convert_runner_path_to_type(host_runner_path)
+
+    incontainer_path = get_incontainer_path(
+        typed_host_path,
+        typed_host_runner_path,
+    )
+    assert expected_incontainer_path == incontainer_path
+
+
+@pytest.mark.parametrize('host_runner_path', ('', 'somewhere/'))
+@pytest.mark.parametrize('convert_runner_path_to_type', (pathlib.Path, str))
+def test_relative_private_data_path_conversion(
+        host_runner_path: os.PathLike[str] | str,
+        convert_runner_path_to_type: PathToTypeCallableType,
+) -> None:
+    """Ensure relative data paths are rejected."""
+    typed_host_runner_path = convert_runner_path_to_type(host_runner_path)
+
+    err_msg_pattern = '^The private_data_dir path must be absolute$'
+    with pytest.raises(RuntimeError, match=err_msg_pattern):
+        get_incontainer_path('', typed_host_runner_path)
+
+
+@pytest.mark.parametrize(
+    ('host_path', 'host_runner_path'),
+    (
+        ('/root', '/home'),
+        ('/tmp/public/subdir', '/tmp/private'),
+    ),
+)
+@pytest.mark.parametrize('convert_path_to_type', (pathlib.Path, str))
+@pytest.mark.parametrize('convert_runner_path_to_type', (pathlib.Path, str))
+def test_paths_outside_private_path_conversion(
+        host_path: os.PathLike[str] | str,
+        host_runner_path: os.PathLike[str] | str,
+        convert_path_to_type: PathToTypeCallableType,
+        convert_runner_path_to_type: PathToTypeCallableType,
+) -> None:
+    """Ensure paths external to private data path are rejected."""
+    resolved_host_path = pathlib.Path(host_path).resolve()
+    resolved_host_runner_path = pathlib.Path(host_runner_path).resolve()
+
+    typed_host_path = convert_path_to_type(host_path)
+    typed_host_runner_path = convert_runner_path_to_type(host_runner_path)
+
+    err_msg_pattern = (
+        f'^Cannot convert path {resolved_host_path !s} unless it is '
+        f'a subdir of {resolved_host_runner_path !s}$'
+    )
+    with pytest.raises(RuntimeError, match=err_msg_pattern) as raised_exc_info:
+        get_incontainer_path(typed_host_path, typed_host_runner_path)
+
+    assert isinstance(raised_exc_info.value.__cause__, ValueError)

--- a/tests/_temporary_private_django_api_test.py
+++ b/tests/_temporary_private_django_api_test.py
@@ -1,0 +1,29 @@
+"""Tests for the temporarily hosted private helpers."""
+
+from collections.abc import Callable
+
+import pytest
+from hypothesis import example, given, strategies as st
+
+from awx_plugins.interfaces._temporary_private_django_api import (
+    get_vmware_certificate_validation_setting,
+    gettext_lazy,
+    gettext_noop,
+)
+
+
+def test_vmware_cert_validation_toggle_stub() -> None:
+    """Ensure the function stub returns enabled value."""
+    assert get_vmware_certificate_validation_setting() is True
+
+
+@example(text_input='криївка')
+@example(text_input='Sich')
+@given(text_input=st.text())
+@pytest.mark.parametrize('invoke_gettext', (gettext_noop, gettext_lazy))
+def test_gettext_functions_returns_input(
+        invoke_gettext: Callable[[str], str],
+        text_input: str,
+) -> None:
+    """Ensure ``gettext`` helpers return the input string."""
+    assert text_input is invoke_gettext(text_input)

--- a/tests/_temporary_private_licensing_api_test.py
+++ b/tests/_temporary_private_licensing_api_test.py
@@ -1,0 +1,34 @@
+"""Tests for the temporarily hosted private helpers."""
+
+import pathlib
+
+import pytest
+
+from awx_plugins.interfaces._temporary_private_licensing_api import (
+    detect_server_product_name,
+)
+
+
+detect_server_product_name_no_cache = detect_server_product_name.__wrapped__
+
+
+@pytest.mark.parametrize(
+    ('path_exists', 'expected_license_name'),
+    (
+        pytest.param(False, 'AWX', id='AWX'),  # noqa: WPS425
+        pytest.param(
+            True,  # noqa: WPS425
+            'Red Hat Ansible Automation Platform',
+            id='AAP',
+        ),
+    ),
+)
+def test_server_product_name_detection(
+        path_exists: bool,
+        expected_license_name: str,
+        monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check the product detection is sound."""
+    with monkeypatch.context() as mp_ctx:
+        mp_ctx.setattr(pathlib.Path, 'exists', lambda _slf: path_exists)
+        assert expected_license_name == detect_server_product_name_no_cache()


### PR DESCRIPTION
This patch moves the AWX bits that are used by `awx-plugins-core` into this project. Many of those things are to be removed in future refactorings.