### PR TITLE
Do not inject extra var for inv update

### DIFF
--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -277,17 +277,18 @@ def inject_credential(
             tmpl,
         ).render(**safe_namespace)
 
-    extra_vars = _build_extra_vars(
-        sandbox_env,
-        namespace,
-        cred_type.injectors.get(
-            'extra_vars', {},
-        ),
-    )
-    if extra_vars:
-        path = _build_extra_vars_file(extra_vars, private_data_dir)
-        container_path = get_incontainer_path(path, private_data_dir)
-        args.extend(
-            # pylint: disable-next=consider-using-f-string
-            ['-e', '@%s' % container_path],
+    if 'INVENTORY_UPDATE_ID' not in env:
+        extra_vars = _build_extra_vars(
+            sandbox_env,
+            namespace,
+            cred_type.injectors.get(
+                'extra_vars', {},
+            ),
         )
+        if extra_vars:
+            path = _build_extra_vars_file(extra_vars, private_data_dir)
+            container_path = get_incontainer_path(path, private_data_dir)
+            args.extend(
+                # pylint: disable-next=consider-using-f-string
+                ['-e', '@%s' % container_path],
+            )

--- a/tests/_temporary_private_inject_api_test.py
+++ b/tests/_temporary_private_inject_api_test.py
@@ -394,6 +394,29 @@ def test_injectors_with_extra_vars(
     assert expected_extra_vars.items() <= extra_vars.items()
 
 
+def test_injectors_inv_update_id(private_data_dir: str) -> None:
+    """Check that extra vars are not injected for an inventory update."""
+    cred_type = ManagedCredentialType(
+        namespace='animal',
+        name='dog',
+        kind='companion',
+        managed=True,
+        inputs={},
+        injectors={'extra_vars': {'do-not-inject': 'should-not-inject'}},
+    )
+    args: ArgsType = []
+    inject_credential(
+        cred_type,
+        Credential(inputs={}),
+        {'INVENTORY_UPDATE_ID': '1'},
+        {},
+        args,
+        private_data_dir,
+    )
+
+    assert not args
+
+
 @pytest.mark.parametrize(
     (
         'inputs',


### PR DESCRIPTION
* This logic was in AWX when inject_credential was originally moved over. I removed it because I couldn't trigger it in unit tests.
* I've since found out that it is needed due to a failing test in AWX and how the env would get set.
* This change includes a unit test to exercise and cover this path now.