### PR TITLE
Add quote filter to credential injector Jinja2 sandbox

### DIFF
--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shlex
 import stat
 import tempfile
 from collections.abc import Mapping
@@ -256,6 +257,7 @@ def inject_credential(
     # referenced in other injectors
 
     sandbox_env = ImmutableSandboxedEnvironment()
+    sandbox_env.filters['quote'] = shlex.quote
 
     file: str | None = None
     files: dict[str, str] = {}

--- a/tests/_temporary_private_inject_api_test.py
+++ b/tests/_temporary_private_inject_api_test.py
@@ -497,6 +497,26 @@ def test_injectors_inv_update_id(private_data_dir: str) -> None:
             },
             id='multiple-files',
         ),
+        pytest.param(
+            {
+                'fields': [
+                    {
+                        'id': 'file_content',
+                        'label': 'File Content',
+                        'type': 'string',
+                    },
+                ],
+            },
+            {
+                'file': {'template': '{{file_content}}'},
+                'env': {'MY_FILE_PATH': '{{tower.filename | quote}}'},
+            },
+            {'file_content': 'secret-data'},
+            {
+                'MY_FILE_PATH': 'secret-data',
+            },
+            id='quote-filter',
+        ),
     ),
 )
 def test_injectors_with_file(


### PR DESCRIPTION
## Summary
It was discovered that we would cause a TemplateAssertionError with custom credentials that used the custom file injector and that would cause us to inject a blank string instead of the file path. The PR is an attempt to address this issue. 

- Register `shlex.quote` as the `quote` filter on the `ImmutableSandboxedEnvironment` used in `inject_credential`, so custom credential type injector templates can use `{{ tower.filename | quote }}`
- Add a test case verifying `{{ tower.filename | quote }}` resolves correctly in env injectors

Related AWX PR: https://github.com/ansible/awx/pull/16484


