### PR TITLE
Fix custom credential file injectors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,9 @@
 
 ci:
   autoupdate_schedule: quarterly  # low frequency to reduce maintenance noise
-  default_language_version:
-    python: python3.13  # nitpick and wemake-python-styleguide crash on 3.14
+
+default_language_version:
+  python: python3.13  # nitpick and wemake-python-styleguide crash on 3.14
 
 repos:
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,9 +90,6 @@ repos:
   rev: v0.38.1
   hooks:
   - id: nitpick-check
-    # NOTE: `nitpick` hasn't been updated for Python 3.14 yet —
-    # NOTE: `importlib.abc.Traversable` was removed.
-    language_version: python3.13
     pass_filenames: false
 
 - repo: https://github.com/pre-commit/pygrep-hooks.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@
 
 ci:
   autoupdate_schedule: quarterly  # low frequency to reduce maintenance noise
+  default_language_version:
+    python: python3.13  # nitpick and wemake-python-styleguide crash on 3.14
 
 repos:
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,6 @@
 ci:
   autoupdate_schedule: quarterly  # low frequency to reduce maintenance noise
 
-default_language_version:
-  python: python3.13  # nitpick and wemake-python-styleguide crash on 3.14
-
 repos:
 - repo: local
   hooks:
@@ -93,6 +90,9 @@ repos:
   rev: v0.38.1
   hooks:
   - id: nitpick-check
+    # NOTE: `nitpick` hasn't been updated for Python 3.14 yet —
+    # NOTE: `importlib.abc.Traversable` was removed.
+    language_version: python3
     pass_filenames: false
 
 - repo: https://github.com/pre-commit/pygrep-hooks.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
   - id: nitpick-check
     # NOTE: `nitpick` hasn't been updated for Python 3.14 yet —
     # NOTE: `importlib.abc.Traversable` was removed.
-    language_version: python3
+    language_version: python3.13
     pass_filenames: false
 
 - repo: https://github.com/pre-commit/pygrep-hooks.git

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -255,29 +255,54 @@ def inject_credential(
     # special `tower` template namespace so the filename can be
     # referenced in other injectors
 
+    has_bare = any(label.find('.') == -1 for label in file_tmpls)
+    has_dotted = any(label.find('.') != -1 for label in file_tmpls)
+    if has_bare and has_dotted:
+        msg = (
+            "Credential type file injectors cannot mix bare 'template' "
+            "and dotted 'template.<x>' labels — the bare value would "
+            'overwrite the dotted namespace or vice-versa'
+        )
+        raise ValueError(msg)
+
     sandbox_env = ImmutableSandboxedEnvironment()
 
+    # Pass 1: create all files to establish paths, so that
+    # tower.filename.* is fully populated before any template
+    # might need to cross-reference another file's path.
+    file_paths: dict[str, tuple[str, str]] = {}
     file: str | None = None
-    files: dict[str, str] = {}
 
+    for file_label, file_tmpl in file_tmpls.items():
+        env_dir = os.path.join(private_data_dir, 'env')
+        path = tempfile.mkstemp(dir=env_dir)[1]
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        container_path = get_incontainer_path(path, private_data_dir)
+        file_paths[file_label] = (path, container_path)
+
+        if file_label.find('.') == -1:
+            file = container_path
+        else:
+            if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
+                tower_namespace.filename = SimpleNamespace()
+            setattr(
+                tower_namespace.filename,
+                file_label.split('.')[1],
+                container_path,
+            )
+
+    if file is not None:
+        tower_namespace.filename = file
+
+    # Pass 2: render templates and write files now that all
+    # tower.filename.* paths are available for cross-references.
     for file_label, file_tmpl in file_tmpls.items():
         data: str = sandbox_env.from_string(file_tmpl).render(
             **namespace,
         )
-        env_dir = os.path.join(private_data_dir, 'env')
-        path = tempfile.mkstemp(dir=env_dir)[1]
-        with open(path, 'w') as f:  # pylint: disable=unspecified-encoding
+        host_path = file_paths[file_label][0]
+        with open(host_path, 'w') as f:  # pylint: disable=unspecified-encoding
             f.write(data)
-        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-        container_path = get_incontainer_path(path, private_data_dir)
-
-        # determine if filename indicates single file or many
-        if file_label.find('.') == -1:
-            file = container_path
-        else:
-            files[file_label.split('.')[1]] = container_path
-
-    tower_namespace.filename = file or SimpleNamespace(**files)
 
     for env_var, tmpl in cred_type.injectors.get('env', {}).items():
         if env_var in ENV_BLOCKLIST:

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -283,9 +283,7 @@ def inject_credential(
         container_path = get_incontainer_path(path, private_data_dir)
         file_paths[file_label] = (path, container_path)
 
-        if '.' not in file_label:
-            file = container_path
-        else:
+        if '.' in file_label:
             # SimpleNamespace.__getattribute__ is typed as -> Any in
             # typeshed, so mypy sees this isinstance() as containing Any.
             if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
@@ -295,6 +293,8 @@ def inject_credential(
                 file_label.split('.')[1],
                 container_path,
             )
+        else:
+            file = container_path
 
     if file is not None:
         tower_namespace.filename = file

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -1,6 +1,7 @@
 """Injectors exercise plugins."""
 
 import os
+import pathlib
 import re
 import stat
 import tempfile
@@ -257,8 +258,8 @@ def inject_credential(
     # special `tower` template namespace so the filename can be
     # referenced in other injectors
 
-    has_bare = any(label.find('.') == -1 for label in file_tmpls)
-    has_dotted = any(label.find('.') != -1 for label in file_tmpls)
+    has_bare = any('.' not in label for label in file_tmpls)
+    has_dotted = any('.' in label for label in file_tmpls)
     if has_bare and has_dotted:
         msg = (
             "Credential type file injectors cannot mix bare 'template' "
@@ -282,9 +283,11 @@ def inject_credential(
         container_path = get_incontainer_path(path, private_data_dir)
         file_paths[file_label] = (path, container_path)
 
-        if file_label.find('.') == -1:
+        if '.' not in file_label:
             file = container_path
         else:
+            # SimpleNamespace.__getattr__ returns Any, making the
+            # isinstance() expression contain Any in mypy's view.
             if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
                 tower_namespace.filename = SimpleNamespace()
             setattr(
@@ -303,8 +306,7 @@ def inject_credential(
             **namespace,
         )
         host_path = file_paths[tmpl_label][0]
-        with open(host_path, 'w') as f:  # pylint: disable=unspecified-encoding
-            f.write(data)
+        pathlib.Path(host_path).write_text(data, encoding='utf-8')
 
     for env_var, tmpl in cred_type.injectors.get('env', {}).items():
         if env_var in ENV_BLOCKLIST:

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -189,6 +189,8 @@ def inject_credential(
         files)
     :param container_root: root directory inside the container to mount
         the private data directory to.
+    :raises ValueError: if file injectors mix bare ``template`` and
+        dotted ``template.<x>`` labels
     :returns: None
     """
     if not cred_type.injectors:

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -298,11 +298,11 @@ def inject_credential(
 
     # Pass 2: render templates and write files now that all
     # tower.filename.* paths are available for cross-references.
-    for file_label, file_tmpl in file_tmpls.items():
+    for tmpl_label, file_tmpl in file_tmpls.items():
         data: str = sandbox_env.from_string(file_tmpl).render(
             **namespace,
         )
-        host_path = file_paths[file_label][0]
+        host_path = file_paths[tmpl_label][0]
         with open(host_path, 'w') as f:  # pylint: disable=unspecified-encoding
             f.write(data)
 

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -286,8 +286,8 @@ def inject_credential(
         if '.' not in file_label:
             file = container_path
         else:
-            # SimpleNamespace.__getattr__ returns Any, making the
-            # isinstance() expression contain Any in mypy's view.
+            # SimpleNamespace.__getattribute__ is typed as -> Any in
+            # typeshed, so mypy sees this isinstance() as containing Any.
             if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
                 tower_namespace.filename = SimpleNamespace()
             setattr(

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -288,9 +288,8 @@ def inject_credential(
             # typeshed, so mypy sees this isinstance() as containing Any.
             if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
                 tower_namespace.filename = SimpleNamespace()
-            filename_ns: SimpleNamespace = tower_namespace.filename
             setattr(
-                filename_ns,
+                tower_namespace.filename,
                 file_label.split('.')[1],
                 container_path,
             )

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -288,8 +288,9 @@ def inject_credential(
             # typeshed, so mypy sees this isinstance() as containing Any.
             if not isinstance(tower_namespace.filename, SimpleNamespace):  # type: ignore[misc]
                 tower_namespace.filename = SimpleNamespace()
+            filename_ns: SimpleNamespace = tower_namespace.filename
             setattr(
-                tower_namespace.filename,
+                filename_ns,
                 file_label.split('.')[1],
                 container_path,
             )

--- a/src/awx_plugins/interfaces/_temporary_private_inject_api.py
+++ b/src/awx_plugins/interfaces/_temporary_private_inject_api.py
@@ -273,7 +273,7 @@ def inject_credential(
     file_paths: dict[str, tuple[str, str]] = {}
     file: str | None = None
 
-    for file_label, file_tmpl in file_tmpls.items():
+    for file_label in file_tmpls:
         env_dir = os.path.join(private_data_dir, 'env')
         path = tempfile.mkstemp(dir=env_dir)[1]
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/_temporary_private_inject_api_test.py
+++ b/tests/_temporary_private_inject_api_test.py
@@ -592,8 +592,7 @@ def test_injectors_with_file_cross_reference(
     key_file_path = str(env['KEY_FILE'])
     config_path = to_host_path(str(env['CONFIG_FILE']), private_data_dir)
 
-    with open(config_path, encoding='utf-8') as config_file:
-        config_content = config_file.read()
+    config_content = Path(config_path).read_text(encoding='utf-8')
 
     assert key_file_path in config_content, (
         f'Config file should contain the key file path {key_file_path!r}, '

--- a/tests/_temporary_private_inject_api_test.py
+++ b/tests/_temporary_private_inject_api_test.py
@@ -530,6 +530,136 @@ def test_injectors_with_file(
 
 
 @pytest.mark.parametrize(
+    'file_injectors',
+    (
+        pytest.param(
+            {
+                'template.ssh_keyfile': '{{ssh_key}}',
+                'template.config_file': (
+                    '[DEFAULT]\nkey_file={{tower.filename.ssh_keyfile}}'
+                ),
+            },
+            id='config-references-keyfile',
+        ),
+        pytest.param(
+            {
+                'template.config_file': (
+                    '[DEFAULT]\nkey_file={{tower.filename.ssh_keyfile}}'
+                ),
+                'template.ssh_keyfile': '{{ssh_key}}',
+            },
+            id='config-before-keyfile-in-dict',
+        ),
+    ),
+)
+def test_injectors_with_file_cross_reference(
+    private_data_dir: str,
+    file_injectors: dict[str, str],
+) -> None:
+    """Check that a file template can reference another file's path.
+
+    This mirrors the OCI credential type pattern from AAP-78106 where
+    a config file contains key_file={{ tower.filename.ssh_keyfile }}.
+    Both dict orderings are tested to ensure the fix is order-independent.
+    """
+    cred_type = ManagedCredentialType(
+        kind='cloudg',
+        name='SomeCloudCrossRef',
+        namespace='foo',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'ssh_key',
+                    'label': 'SSH Key',
+                    'type': 'string',
+                },
+            ],
+        },
+        injectors={
+            'file': file_injectors,
+            'env': {
+                'CONFIG_FILE': '{{tower.filename.config_file}}',
+                'KEY_FILE': '{{tower.filename.ssh_keyfile}}',
+            },
+        },
+    )
+    credential = Credential(inputs={'ssh_key': 'PRIVATE_KEY_DATA'})
+
+    env: EnvVarsType = {}
+    inject_credential(cred_type, credential, env, {}, [], private_data_dir)
+
+    key_file_path = str(env['KEY_FILE'])
+    config_path = to_host_path(str(env['CONFIG_FILE']), private_data_dir)
+
+    with open(config_path, encoding='utf-8') as config_file:
+        config_content = config_file.read()
+
+    assert key_file_path in config_content, (
+        f'Config file should contain the key file path {key_file_path!r}, '
+        f'got: {config_content!r}'
+    )
+
+
+def test_injectors_with_mixed_file_labels(
+    private_data_dir: str,
+) -> None:
+    """Check that mixing bare 'template' and dotted 'template.<x>' raises.
+
+    A credential type whose file injectors contain both ``template``
+    (which sets ``tower.filename`` to a single path string) and
+    ``template.<x>`` (which stores paths as ``tower.filename.<x>``)
+    is ambiguous: the bare value would overwrite the namespace or vice-versa,
+    silently breaking ``{{ tower.filename }}`` or ``{{ tower.filename.<x> }}``
+    references in other injectors.
+    """
+    cred_type = ManagedCredentialType(
+        kind='cloudy',
+        name='MixedLabels',
+        namespace='foo',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'api_token',
+                    'label': 'API Token',
+                    'type': 'string',
+                },
+                {
+                    'id': 'cert',
+                    'label': 'Certificate',
+                    'type': 'string',
+                },
+            ],
+        },
+        injectors={
+            'file': {
+                'template': '[mycloud]\n{{api_token}}',
+                'template.cert': '{{cert}}',
+            },
+            'env': {
+                'MY_CLOUD_INI_FILE': '{{tower.filename}}',
+                'MY_CERT_FILE': '{{tower.filename.cert}}',
+            },
+        },
+    )
+    credential = Credential(
+        inputs={'api_token': 'ABC456', 'cert': 'CERT_DATA'},
+    )
+
+    env: EnvVarsType = {}
+    with pytest.raises(ValueError, match='cannot mix'):
+        inject_credential(
+            cred_type,
+            credential,
+            env,
+            {},
+            [],
+            private_data_dir,
+        )
+
+
+@pytest.mark.parametrize(
     'managed',
     (True, False),  # noqa: WPS425
 )


### PR DESCRIPTION
## Summary

Fix custom credential type file injection so that file templates can cross-reference other injected file paths (e.g. `{{ tower.filename.ssh_keyfile }}`).

### Two-pass file injection

When `inject_credential` was moved from awx to awx_plugins.interfaces ([38f76f0f](https://github.com/ansible/awx_plugins.interfaces/commit/38f76f0f835173ffda89cf6ea279c35cf5e87aad)), the file injection loop was refactored to collect file paths into local variables and assign `tower_namespace.filename` after the loop:

```python
# Before (broken) — renders templates before tower.filename.* is populated
for file_label, file_tmpl in file_tmpls.items():
    data = sandbox_env.from_string(file_tmpl).render(**namespace)
    ...
    files[file_label.split('.')[1]] = container_path

tower_namespace.filename = file or SimpleNamespace(**files)
```

This broke file templates that cross-reference other injected file paths. For example, an OCI credential type where a config file references `{{ tower.filename.ssh_keyfile }}` — `tower.filename` is still `None` when the template renders, so the path ends up blank.

The fix splits file injection into two passes:
1. **Pass 1**: Create all temp files and populate `tower.filename.*` paths
2. **Pass 2**: Render and write templates, now that all paths are available for cross-references

### Mixed file label validation

Added validation to reject credential types that mix bare `template` and dotted `template.<x>` file labels. These forms are incompatible — the bare form sets `tower.filename` to a string while dotted forms use a `SimpleNamespace`, and one would silently overwrite the other.

## Related Issues

- https://redhat.atlassian.net/browse/AAP-78147 — Custom credential file injectors not setting environment variables
- https://redhat.atlassian.net/browse/AAP-78106 — SRE report: custom credential types broken after 2.7 upgrade
- https://github.com/ansible/awx/pull/16484 — Reproducer test (draft)

## Test plan

- [x] Existing unit tests pass
- [x] New `test_injectors_with_file_cross_reference` — validates cross-referencing works in both dict orderings
- [x] New `test_injectors_with_mixed_file_labels` — validates that mixing bare and dotted labels raises `ValueError`
- [ ] Live integration test in awx repo
